### PR TITLE
Don't use polling to determine when testing is over.

### DIFF
--- a/lib/console-runner.js
+++ b/lib/console-runner.js
@@ -58,6 +58,11 @@
     this.log(spec_str + fail_str + (dur/1000) + "s.", color);
 
     this.status = (failed > 0)? this.statuses.fail : this.statuses.success;
+
+    /* Print something that signals that testing is over so that headless browsers
+       like PhantomJs know when to terminate. */
+    this.log("");
+    this.log("ConsoleReporter finished");
   };
 
 


### PR DESCRIPTION
This allows to run long-running tests, e.g. complex user interactions that have to wait for server responses.

Great job, by the way!
