### PR TITLE
Print failure message if provided

### DIFF
--- a/lib/console-runner.js
+++ b/lib/console-runner.js
@@ -81,10 +81,7 @@
 
     var items = spec.results().getItems()
     for (var i = 0; i < items.length; i++) {
-      var message = items[i].message;
-      if (message)
-          this.log(message, "red");
-      var trace = items[i].trace.stack || items[i].trace;
+      var trace = items[i].trace.stack || items[i].message;
       this.log(trace, "red");
     }
   };

--- a/lib/console-runner.js
+++ b/lib/console-runner.js
@@ -81,6 +81,9 @@
 
     var items = spec.results().getItems()
     for (var i = 0; i < items.length; i++) {
+      var message = items[i].message || "";
+      if (message)
+          this.log(message, "red");
       var trace = items[i].trace.stack || items[i].trace;
       this.log(trace, "red");
     }

--- a/lib/console-runner.js
+++ b/lib/console-runner.js
@@ -81,7 +81,7 @@
 
     var items = spec.results().getItems()
     for (var i = 0; i < items.length; i++) {
-      var message = items[i].message || "";
+      var message = items[i].message;
       if (message)
           this.log(message, "red");
       var trace = items[i].trace.stack || items[i].trace;


### PR DESCRIPTION
I've noticed that the failure message contained in the result items wasn't printed out on the console. Only the trace | trace.stack was. This pull request prints the message as well if provided.
