### PR TITLE
Update bin/phantom-jasmine

### DIFF
--- a/bin/phantom-jasmine
+++ b/bin/phantom-jasmine
@@ -12,4 +12,7 @@ var cmds = [
 
 exec(cmds.join(' '), function(err, stdout, stderr) {
   console.log(stdout);
+  if(err){
+    process.exit(1);
+  }
 });


### PR DESCRIPTION
Exit node with an error-status-code when testing fails. Otherwise node always exits with status-code 0. This is important when building a project on a buildserver such as jenkins.

Have a nice day.
