### PR TITLE
will wait to terminate if status is still running

### DIFF
--- a/lib/run_jasmine_test.coffee
+++ b/lib/run_jasmine_test.coffee
@@ -15,6 +15,7 @@ class PhantomJasmineRunner
     switch @get_status()
       when "success" then @exit_func 0
       when "fail"    then @exit_func 1
+      when "running" then setTimeout (=> @terminate()), 100 # wait if the status is still running
       else                @exit_func 2
 
 # Script Begin


### PR DESCRIPTION
It gave a false negative and returning an error code of 2 if the status was running, so now it waits until the status isn't running before terminating.
