### PR TITLE
Add support for phantomJS 2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# don't check in compiled js from lib/run_jasmine_test.coffee
+lib/run_jasmine_test.js
+node_modules

--- a/bin/phantom-jasmine
+++ b/bin/phantom-jasmine
@@ -6,7 +6,7 @@ var lib = path.join(__dirname, './../lib');
 
 var cmds = [
   'phantomjs',
-  path.join(lib, 'run_jasmine_test.coffee'),
+  path.join(lib, 'run_jasmine_test.js'),
   process.argv[2]
 ];
 

--- a/lib/run_jasmine_test.coffee
+++ b/lib/run_jasmine_test.coffee
@@ -18,7 +18,12 @@ class PhantomJasmineRunner
       else                @exit_func 2
 
 # Script Begin
-if phantom.args.length == 0
+args = phantom.args
+
+if !args?
+    args = require('system').args
+
+if args.length == 0
   console.log "Need a url as the argument"
   phantom.exit 1
 
@@ -36,7 +41,7 @@ page.onConsoleMessage = (msg) ->
   if msg == "ConsoleReporter finished"
     runner.terminate()
 
-address = phantom.args[0]
+address = args[0]
 
 page.open address, (status) ->
   if status != "success"

--- a/lib/run_jasmine_test.coffee
+++ b/lib/run_jasmine_test.coffee
@@ -18,14 +18,20 @@ class PhantomJasmineRunner
       else                @exit_func 2
 
 # Script Begin
-args = phantom.args
+args = undefined
 
-if !args?
+if phantom.version.major <= 1
+    args = phantom.args
+    if args.length == 0
+        console.log "Need a url as the argument"
+        phantom.exit 1
+    address = args[0]
+else
     args = require('system').args
-
-if args.length == 0
-  console.log "Need a url as the argument"
-  phantom.exit 1
+    if args.length == 1
+        console.log "Need a url as the argument"
+        phantom.exit 1
+    address = args[1]
 
 page = new WebPage()
 
@@ -40,8 +46,6 @@ page.onConsoleMessage = (msg) ->
   # so we have to *observe* the website.
   if msg == "ConsoleReporter finished"
     runner.terminate()
-
-address = args[0]
 
 page.open address, (status) ->
   if status != "success"

--- a/package.json
+++ b/package.json
@@ -11,16 +11,21 @@
     "type": "git",
     "url": "git://github.com/jcarver989/phantom-jasmine.git"
   },
-  "main": "lib/run_jasmine_test.coffee",
+  "main": "lib/run_jasmine_test.js",
   "version": "0.1.0",
   "bin": {
     "phantom-jasmine": "./bin/phantom-jasmine"
   },
   "preferGlobal": true,
   "dependencies": {},
-  "devDependencies": {},
+  "devDependencies": {
+    "coffee-script": "^1.9.1"
+  },
   "optionalDependencies": {},
   "engines": {
     "node": "*"
+  },
+  "scripts": {
+    "prepublish": "node_modules/coffee-script/bin/coffee -c lib/run_jasmine_test.coffee"
   }
 }


### PR DESCRIPTION
- Update `run_jasmine_test.coffee` because phantom.args is deprecated in phantomjs 2.0 (http://phantomjs.org/api/phantom/property/args.html)
- Add prepublish step to compile the coffe script and use javascript file instead because phantomjs 2.0 doesn't support coffe script.
